### PR TITLE
Add BusyBox-style symlink support for PyKnife commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ PyKnife provides pure Python implementations of common Linux command-line tools.
 - Pure Python 3 implementation
 - Minimal dependencies (uses primarily the Python standard library)
 - Commands match the behavior of their Linux counterparts
+- BusyBox-style invocation through symlinks
 
 ## Currently Implemented Commands
 
@@ -29,11 +30,42 @@ python src/cli.py echo "Hello, World!"
 
 ## Usage
 
+PyKnife can be used in two ways:
+
+### 1. Specifying Command as an Argument
+
 ```
 python src/cli.py COMMAND [ARGS]
 ```
 
-Where `COMMAND` is one of the implemented commands (e.g., `echo`).
+For example:
+```bash
+python src/cli.py echo "Hello, World!"
+python src/cli.py pwd
+```
+
+### 2. BusyBox-Style Symlink Invocation
+
+You can set up symlinks to run commands directly, similar to BusyBox:
+
+```bash
+# Setup symlinks in a directory (e.g., ~/bin)
+python scripts/setup_symlinks.py ~/bin
+
+# Now you can run commands directly
+~/bin/echo "Hello, World!"
+~/bin/pwd
+```
+
+On Windows, use:
+```
+python scripts\setup_symlinks.py .\bin --py
+python .\bin\echo.py "Hello, World!"
+```
+
+This symlink-based approach allows you to use PyKnife commands just like their native counterparts!
+
+## Documentation
 
 See the [documentation](docs/commands/) for details on each command.
 

--- a/scripts/setup_symlinks.py
+++ b/scripts/setup_symlinks.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+Setup symlinks for PyKnife commands.
+
+This script creates symlinks in the specified directory for all available
+PyKnife commands, pointing to the main CLI script. This allows commands
+to be invoked directly by name, similar to how BusyBox works.
+"""
+
+import os
+import sys
+import argparse
+import importlib
+import shutil
+from pathlib import Path
+
+
+def get_available_commands():
+    """Get a list of all available PyKnife commands."""
+    try:
+        sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        from src.commands import __all__ as commands
+        return commands
+    except (ImportError, AttributeError):
+        print("Error: Could not import command list from src.commands", file=sys.stderr)
+        return []
+
+
+def setup_symlinks(target_dir, use_py_extension=False, force=False):
+    """
+    Create symlinks for all PyKnife commands.
+    
+    Args:
+        target_dir (str): Directory where symlinks will be created
+        use_py_extension (bool): Whether to add .py extension to symlinks
+        force (bool): Whether to overwrite existing files
+    """
+    commands = get_available_commands()
+    if not commands:
+        print("No commands found to create symlinks for.", file=sys.stderr)
+        return 1
+    
+    # Get the absolute path to the CLI script
+    cli_script = os.path.abspath(os.path.join(
+        os.path.dirname(os.path.dirname(__file__)),
+        'src', 'cli.py'
+    ))
+    
+    # Ensure the target directory exists
+    target_dir = os.path.abspath(target_dir)
+    os.makedirs(target_dir, exist_ok=True)
+    
+    # Create symlinks for all commands
+    created = 0
+    skipped = 0
+    for command in commands:
+        # Determine the symlink name
+        symlink_name = f"{command}.py" if use_py_extension else command
+        symlink_path = os.path.join(target_dir, symlink_name)
+        
+        # Check if the symlink already exists
+        if os.path.exists(symlink_path):
+            if force:
+                try:
+                    os.remove(symlink_path)
+                except OSError as e:
+                    print(f"Warning: Could not remove existing file '{symlink_path}': {e}")
+                    skipped += 1
+                    continue
+            else:
+                print(f"Skipping: '{symlink_path}' already exists (use --force to overwrite)")
+                skipped += 1
+                continue
+        
+        # Create the symlink
+        try:
+            # Use relative path for the target if possible
+            try:
+                # Get relative path from symlink to cli.py
+                target = os.path.relpath(cli_script, target_dir)
+            except ValueError:
+                # If on different drives (Windows), use absolute path
+                target = cli_script
+            
+            # Create the symlink
+            if os.name == 'nt':  # Windows
+                # Windows requires admin privileges for symlinks, so copy instead
+                shutil.copy2(cli_script, symlink_path)
+                print(f"Created copy: {symlink_path} -> {target}")
+            else:
+                # Unix systems can use symlinks
+                os.symlink(target, symlink_path)
+                print(f"Created symlink: {symlink_path} -> {target}")
+            created += 1
+        except OSError as e:
+            print(f"Error creating symlink '{symlink_path}': {e}")
+            skipped += 1
+    
+    print(f"\nSummary: Created {created} symlinks, skipped {skipped}")
+    
+    if created > 0:
+        print("\nYou can now run commands directly:")
+        example_cmd = next(iter(commands))
+        example_path = os.path.join(target_dir, example_cmd)
+        if os.name == 'nt':  # Windows
+            example_path += ".py" if use_py_extension else ""
+            print(f"  python {example_path} [ARGS]")
+        else:
+            print(f"  {example_path} [ARGS]")
+    
+    return 0
+
+
+def main():
+    """Parse command line arguments and setup symlinks."""
+    parser = argparse.ArgumentParser(description="Create symlinks for PyKnife commands")
+    parser.add_argument(
+        "target_dir", 
+        help="Directory where symlinks will be created"
+    )
+    parser.add_argument(
+        "--py", action="store_true",
+        help="Add .py extension to symlinks"
+    )
+    parser.add_argument(
+        "--force", action="store_true",
+        help="Overwrite existing files"
+    )
+    
+    args = parser.parse_args()
+    
+    return setup_symlinks(args.target_dir, args.py, args.force)
+
+
+if __name__ == "__main__":
+    sys.exit(main()) 

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 """
 PyKnife - Python implementation of common Linux CLI tools.
+
+This CLI can be used in two ways:
+1. By specifying the command as the first argument: `python cli.py echo "hello"`
+2. By creating symlinks to this file with the command name and running them directly:
+   - Create a symlink: `ln -s cli.py pwd` or `ln -s cli.py pwd.py`
+   - Then run: `./pwd` or `python pwd.py`
 """
 
 import sys
@@ -9,16 +15,52 @@ import os
 from importlib import import_module
 
 
+def get_command_from_script_name(script_path):
+    """
+    Extract the command name from the script name.
+    This allows the CLI to be invoked via symlinks.
+    
+    Examples:
+    - 'cli.py' -> None (use command-line argument)
+    - 'pwd' -> 'pwd'
+    - 'pwd.py' -> 'pwd'
+    - '/path/to/echo' -> 'echo'
+    - '/path/to/echo.py' -> 'echo'
+    """
+    # Get just the filename without the path
+    script_name = os.path.basename(script_path)
+    
+    # If it's the main CLI script, return None
+    if script_name in ['cli.py', 'cli']:
+        return None
+    
+    # Remove '.py' extension if present
+    if script_name.endswith('.py'):
+        script_name = script_name[:-3]
+    
+    return script_name
+
+
 def main():
     """Main entry point for the CLI."""
-    if len(sys.argv) < 2:
+    # Determine how the script was invoked
+    script_path = sys.argv[0]
+    command_from_name = get_command_from_script_name(script_path)
+    
+    if command_from_name:
+        # Invoked via symlink (e.g., ./pwd or python pwd.py)
+        command = command_from_name
+        command_args = sys.argv[1:]  # All args are for the command
+    elif len(sys.argv) < 2:
+        # Invoked as cli.py but without a command
         print("Error: No command specified", file=sys.stderr)
         print(f"Usage: {sys.argv[0]} COMMAND [ARGS]", file=sys.stderr)
         sys.exit(1)
-
-    command = sys.argv[1]
-    command_args = sys.argv[2:]
-
+    else:
+        # Invoked as cli.py with a command
+        command = sys.argv[1]
+        command_args = sys.argv[2:]  # Skip the command name
+    
     try:
         # Add the parent directory to sys.path so imports work correctly
         sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))


### PR DESCRIPTION
Implement a flexible symlink mechanism for running PyKnife commands:
- Create setup_symlinks.py script to generate command symlinks
- Update CLI to support invocation via symlinks
- Enhance README with symlink usage instructions
- Add cross-platform support for symlink creation (Windows and Unix)